### PR TITLE
Rename to react-native-simple-router (see #2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 react-native-simple-router
+Copyright (c) 2016 react-native-simple-router authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-GB Native Router
+React Native Simple Router
 ===================
 
 Awesome navigation for your React Native app.
@@ -11,13 +11,13 @@ Install
 Make sure that you are in your React Native project directory and run:
 
 
-```$ npm install gb-native-router --save```
+```$ npm install react-native-simple-router --save```
 
 Usage
 -----
 
 ```javascript
-var Router = require('gb-native-router');
+var Router = require('react-native-simple-router');
 ```
 
 The basics:
@@ -141,12 +141,12 @@ Events emitted by the router:
 A more advanced example: Twitter app
 ------------------------------------
 
-To see more of the router in action, you can check out the Twitter example app that comes with the package. Just make sure that you first drag all the images from ```node_modules/react-native-router/twitter-example/images``` to your project's Images.xcassets
+To see more of the router in action, you can check out the Twitter example app that comes with the package. Just make sure that you first drag all the images from ```node_modules/react-native-simple-router/twitter-example/images``` to your project's Images.xcassets
 
 After that, don't forget to rebuild the app in XCode before you launch the simulator. Then test the app by requiring the TwitterApp component:
 
 ```javascript
-var TwitterApp = require('./node_modules/react-native-router/twitter-example');
+var TwitterApp = require('./node_modules/react-native-simple-router/twitter-example');
 
 var {
   AppRegistry

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
-  "name": "gb-native-router",
+  "name": "react-native-simple-router",
   "version": "0.6.0",
   "description": "Easy to use Navigator for your native app.",
-  "author": "Mikael Carpenter <mikaelcarp.dev@gmail.com>",
+  "author": "Tristan Edwards <tristan.edwards@me.com> (http://tristanedwards.me)",
+  "contributors": [
+    "Mikael Carpenter",
+    "David Leonardi"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MikaelCarpenter/gb-native-router.git"
+    "url": "https://github.com/react-native-simple-router-community/react-native-simple-router.git"
   },
   "keywords": [
     "react",
@@ -23,9 +27,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/MikaelCarpenter/gb-native-router/issues"
+    "url": "https://github.com/react-native-simple-router-community/react-native-simple-router/issues"
   },
-  "homepage": "https://github.com/MikaelCarpenter/gb-native-router",
+  "homepage": "https://github.com/react-native-simple-router-community/react-native-simple-router",
   "dependencies": {},
   "peerDependencies": {
     "react-native": ">=0.12.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc",


### PR DESCRIPTION
This (hopefully) renames all name references of this package from either gb-native-router or
react-native-router to react-native-simple-router.

The npm package authors were modified to acknowledge the original work
by Tristan and Mikael.
