### PR TITLE
Make fbemitter an actual dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-simple-router",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Easy to use Navigator for your native app.",
   "author": "Tristan Edwards <tristan.edwards@me.com> (http://tristanedwards.me)",
   "contributors": [
@@ -31,10 +31,11 @@
     "url": "https://github.com/react-native-simple-router-community/react-native-simple-router/issues"
   },
   "homepage": "https://github.com/react-native-simple-router-community/react-native-simple-router",
-  "dependencies": {},
+  "dependencies": {
+    "fbemitter": "^2.0.1"
+  },
   "peerDependencies": {
-    "react-native": ">=0.12.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc || 0.17.0-rc || 0.18.0-rc",
-    "fbemitter": "^2.0.0"
+    "react-native": ">=0.12.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc || 0.17.0-rc || 0.18.0-rc"
   },
   "devDependencies": {
     "eslint": "^1.10.3",


### PR DESCRIPTION
`fbemitter` should be a `dependency` not a `peerDependency` of this project because this project actually includes/requires it for internal usage.

Also, `peerDependencies` are just completely broken in all kinds of ways currently for npm 2 and npm 3
