### PR TITLE
Fix opacity issue with NavBarContent

### DIFF
--- a/components/NavBarContent.js
+++ b/components/NavBarContent.js
@@ -87,6 +87,8 @@ class NavBarContent extends React.Component {
           }
         ).start();
       }, 0);
+    } else if (newProps.route === this.props.route) {
+      this.state.opacity.setValue(1);
     }
   }
 


### PR DESCRIPTION
Fixed an issue with opacity when we back to a previous route and title didn't appear.

I got this issue when I back from `hideNavigationBar` and `trans` are true to a route with visible navigation bar, the title had opacity 0.

This pull should fixed this issue and ensure that title of current route is visible.
