### PR TITLE
Fix 0.7.0 rc

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,10 @@ class Router extends React.Component {
     this.emitter = new EventEmitter();
   }
 
+  componentWillMount() {
+    this.state.route = this.props.firstRoute;
+  }
+
   componentDidMount() {
     this.refs.navigator.navigationContext.addListener('willfocus', (event) => {
       const route = event.data.route;

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class Router extends React.Component {
       this.onWillPush(route);
     });
     aspect.after(this.refs.navigator, 'push', (route) => {
-        //temporary hack to fix bug in aspect library
+      // temporary hack to fix bug in aspect library
       this.onDidPush(route || arguments[1]);
     });
 
@@ -108,7 +108,7 @@ class Router extends React.Component {
       this.onWillResetTo(route);
     });
     aspect.after(this.refs.navigator, 'resetTo', (route) => {
-        //temporary hack to fix bug in aspect library
+      // temporary hack to fix bug in aspect library
       this.onDidResetTo(route || arguments[1]);
     });
 
@@ -116,7 +116,7 @@ class Router extends React.Component {
       this.onWillReplace(route);
     });
     aspect.after(this.refs.navigator, 'replace', (route) => {
-        //temporary hack to fix bug in aspect library
+      // temporary hack to fix bug in aspect library
       this.onDidReplace(route || arguments[1]);
     });
 


### PR DESCRIPTION
Fix to PR #47.

Since we use `navigationContext` listener : 

``` javascript
  componentDidMount() {
    this.refs.navigator.navigationContext.addListener('willfocus', (event) => {
      const route = event.data.route;
      this.setState({ route });
      this.emitter.emit('willFocus', route.name);
    });
}
```

`willfocus` was not called on first route, so the setState route was not called too and it caused problems with the first route. In my case, the props was not apply to my first route.
