### PR TITLE
Status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The **`<Router />`** object used to initialize the navigation can take the follo
 - `customAction`: A special callback prop for your action buttons (this can be handy for triggering a side menu for example). The action gets triggered from your custom `leftCorner` or `rightCorner` components by calling `this.props.customAction("someActionName")` from them. It is then picked up like this: `<Router customAction={this.doSomething} />`.
 - `hideNavigationBar`: Hide the navigation bar, always
 - `handleBackAndroid` (Boolean value): Apply a listener to the native back button on Android. On click, it will go to the previous route until it reach the first scene, then it will exit the app.
+- `statusBarProps`: Default StatusBar props, please refer to [StatusBar Docs](https://facebook.github.io/react-native/docs/statusbar.html#content). (Android) If `backgroundColor` isn't provided, it will take the same color as defined in `headerStyle`.
 
 
 The **`this.props.toRoute()`** callback prop takes one parameter (a JavaScript object) which can have the following keys:
@@ -148,6 +149,7 @@ The **`this.props.toRoute()`** callback prop takes one parameter (a JavaScript o
   - Navigator.SceneConfigs.PushFromRight
   - Navigator.SceneConfigs.VerticalDownSwipeJump
   - Navigator.SceneConfigs.VerticalUpSwipeJump
+- `statusBarProps`: Route specific StatusBar props, it will override `statusBarProps` defined in Router, please refer to [StatusBar Docs](https://facebook.github.io/react-native/docs/statusbar.html#content).
 
 The **`this.props.replaceRoute`** function takes in an object that can contain the same keys as `toRoute()`. The difference is that instead of adding a route to your stack, it replaces the route
 that you're on with the new route that you pass it.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/react-native-simple-router-community/react-native-simple-router",
   "dependencies": {
-    "aspect-js": "^1.0.3"
+    "aspect-js": "^1.0.3",
+    "underscore": "^1.8.3"
   },
   "peerDependencies": {
     "react-native": ">=0.12.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc || 0.17.0-rc || 0.18.0-rc || 0.19.0-rc || 0.20.0-rc || 0.20.0-rc1"

--- a/twitter-example/index.js
+++ b/twitter-example/index.js
@@ -19,6 +19,10 @@ const styles = StyleSheet.create({
   },
 });
 
+const statusBarProps = {
+  backgroundColor: '#1b6298',
+};
+
 export default class TwitterApp extends React.Component {
   render() {
     return (
@@ -27,6 +31,7 @@ export default class TwitterApp extends React.Component {
         headerStyle={styles.header}
         backButtonComponent={BackButton}
         rightCorner={SearchAndCompose}
+        statusBarProps={statusBarProps}
       />
     );
   }


### PR DESCRIPTION
- Add status bar cross platform
- On Android, by default iit use same color as defined in `headerStyle` instead of gray status bar.
- Can be translucent (like iOS) We can now draw under the status bar!

See [StatusBar Docs](https://facebook.github.io/react-native/docs/statusbar.html#content) for further details.
