### PR TITLE
Center navigation content title always

### DIFF
--- a/components/NavBarContent.js
+++ b/components/NavBarContent.js
@@ -205,7 +205,7 @@ class NavBarContent extends React.Component {
       );
     }
 
-    if (Platform.OS === 'ios' || this.props.route.rightCorner || this.props.rightCorner) {
+    if (Platform.OS === 'ios' || this.props.route.rightCorner || this.props.route.index > 0) {
       rightCorner = (
         <View style={[styles.corner, styles.alignRight]}>
           {rightCornerContent}


### PR DESCRIPTION
If we don't show the right corner when we default to show
the left corner, we end up with a [ flex 1 | flex 6 ] setup
where the title is centered "off-center" because of the uneven
flex total of 7.  Forcing an empty default right corner gets us
back to [ flex 1 | flex 6 | flex 1 ] by default which gives
a truly centered nav title
