### PR TITLE
include route in args for willFocus/didFocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ The functions **`this.props.setRightProps`**, **`this.props.setLeftProps`** and 
 
 As of 0.7.0 the router acts as a relay for events emitted by the navigator, and extends these to the following list:
 
-  - `willFocus`: Emitted when a route will focus. Emits the route name as a string.
-  - `didFocus`: Emitted when a route did focus. Emits the route name as a string.
+  - `willFocus`: Emitted when a route will focus. Passes {String} route name and {Object} route as args.
+  - `didFocus`: Emitted when a route did focus. Passes {String} route name and {Object} route as args.
   - `willPop`: Emitted when a route stack will be popped. Triggered by `Navigator.pop();`
   - `didPop`: Emitted when a route stack did pop. Triggered by `Navigator.pop();`
   - `willPush`: Emitted when a new route will be pushed to the route stack. Emits the new route object. Triggered by `Navigator.push(route);`
@@ -181,8 +181,8 @@ As of 0.7.0 the router acts as a relay for events emitted by the navigator, and 
 You can listen to these events by adding an event listener as such:
 
 ```javascript
-  	this.props.routeEmitter.addListener('didFocus', (name) => {
-		//Do something with name..
+  	this.props.routeEmitter.addListener('didFocus', (name, route) => {
+		//Do something with name or route...
 	});
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ The functions **`this.props.setRightProps`**, **`this.props.setLeftProps`** and 
 
 As of 0.7.0 the router acts as a relay for events emitted by the navigator, and extends these to the following list:
 
-  - `willFocus`: Emitted when a route will focus. Passes {String} route name and {Object} route as args.
-  - `didFocus`: Emitted when a route did focus. Passes {String} route name and {Object} route as args.
+  - `willFocus`: Emitted when a route will focus. Emits route object.
+  - `didFocus`: Emitted when a route did focus. Emits route object.
   - `willPop`: Emitted when a route stack will be popped. Triggered by `Navigator.pop();`
   - `didPop`: Emitted when a route stack did pop. Triggered by `Navigator.pop();`
   - `willPush`: Emitted when a new route will be pushed to the route stack. Emits the new route object. Triggered by `Navigator.push(route);`
@@ -181,9 +181,9 @@ As of 0.7.0 the router acts as a relay for events emitted by the navigator, and 
 You can listen to these events by adding an event listener as such:
 
 ```javascript
-  	this.props.routeEmitter.addListener('didFocus', (name, route) => {
-		//Do something with name or route...
-	});
+  this.props.routeEmitter.addListener('didFocus', (route) => {
+      console.log(route.name, 'didFocus');
+  });
 ```
 
 As of v0.8.0 the `leftCorner`, `rightCorner` and `titleComponent` have access to the following router functions :

--- a/index.js
+++ b/index.js
@@ -83,12 +83,12 @@ class Router extends React.Component {
     this.refs.navigator.navigationContext.addListener('willfocus', (event) => {
       const route = event.data.route;
       this.setState({ route });
-      this.emitter.emit('willFocus', route.name, route);
+      this.emitter.emit('willFocus', route);
     });
 
     this.refs.navigator.navigationContext.addListener('didfocus', (event) => {
       const route = event.data.route;
-      this.emitter.emit('didFocus', route.name, route);
+      this.emitter.emit('didFocus', route);
     });
 
     aspect.before(this.refs.navigator, 'pop', () => {

--- a/index.js
+++ b/index.js
@@ -83,12 +83,12 @@ class Router extends React.Component {
     this.refs.navigator.navigationContext.addListener('willfocus', (event) => {
       const route = event.data.route;
       this.setState({ route });
-      this.emitter.emit('willFocus', route.name);
+      this.emitter.emit('willFocus', route.name, route);
     });
 
     this.refs.navigator.navigationContext.addListener('didfocus', (event) => {
       const route = event.data.route;
-      this.emitter.emit('didFocus', route.name);
+      this.emitter.emit('didFocus', route.name, route);
     });
 
     aspect.before(this.refs.navigator, 'pop', () => {


### PR DESCRIPTION
This address #90, providing access to the `route` along with `route.name` so the user can query the route for whatever is needed. 
