### PR TITLE
Add ESLint as the default npm test for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,25 +101,25 @@ class Router extends React.Component {
     aspect.before(this.refs.navigator, 'push', (route) => {
       this.onWillPush(route);
     });
-    aspect.after(this.refs.navigator, 'push', (route) => {
+    aspect.after(this.refs.navigator, 'push', (route, ...args) => {
       // temporary hack to fix bug in aspect library
-      this.onDidPush(route || arguments[1]);
+      this.onDidPush(route || args[1]);
     });
 
     aspect.before(this.refs.navigator, 'resetTo', (route) => {
       this.onWillResetTo(route);
     });
-    aspect.after(this.refs.navigator, 'resetTo', (route) => {
+    aspect.after(this.refs.navigator, 'resetTo', (route, ...args) => {
       // temporary hack to fix bug in aspect library
-      this.onDidResetTo(route || arguments[1]);
+      this.onDidResetTo(route || args[1]);
     });
 
     aspect.before(this.refs.navigator, 'replace', (route) => {
       this.onWillReplace(route);
     });
-    aspect.after(this.refs.navigator, 'replace', (route) => {
+    aspect.after(this.refs.navigator, 'replace', (route, ...args) => {
       // temporary hack to fix bug in aspect library
-      this.onDidReplace(route || arguments[1]);
+      this.onDidReplace(route || args[1]);
     });
 
     aspect.before(this.refs.navigator, 'popToTop', () => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint . --ignore-pattern examples/"
   },
   "repository": {
     "type": "git",
@@ -41,8 +41,8 @@
   },
   "devDependencies": {
     "eslint": "^2.7.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-react": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^1.2.0"
   }
 }


### PR DESCRIPTION
We have a CI in place that will run `npm test` on pull request, so we
might as well use it for something meaningful like ESLint.

The `example/` are ignored for now because of too many errors. If anyone
wants to pick that up, feel free.

This also fixes small ESLint complaints.
