### PR TITLE
Bugfix for Maximum call stack size exceeded

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,7 +286,7 @@ class Router extends React.Component {
     };
 
     const customAction = (opts) => {
-      this.customAction(opts);
+      this.props.customAction(opts);
     };
 
     const Content = route.component;


### PR DESCRIPTION
- use this.props.customAction instead of this.customAction

Fixes issue: #140 @michelantonides
