### PR TITLE
Added getCurrentRoutes functionality without the need of ref. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ that you're on with the new route that you pass it, and empties the navigation s
 
 The **`this.props.popToRoute`** function takes in an object that can contain the same keys as `toRoute()`. The difference is that instead of adding a route to your stack, it pop all routes until the desired one.
 
+   The **`this.props.getCurrentRoutes()`** returns the current list of routes (same as [ReactNative Navigator getCurrentRoutes(0)]( https://facebook.github.io/react-native/docs/navigator.html#getcurrentroutes) ). This can be used as an argument for `popToRoute()`.
+
 The functions **`this.props.setRightProps`**, **`this.props.setLeftProps`** and  **`this.props.setTitleProps`** take in an object of props and sends that to your navbar's `RightComponent`, `LeftComponent` or `TitleComponent`, respectively.
 - This allows you to talk directly to your navbar, because previously you could only talk to it when navigating forward or backward.
 

--- a/index.js
+++ b/index.js
@@ -234,7 +234,9 @@ class Router extends React.Component {
   setTitleProps(props) {
     this.setState({ titleProps: props });
   }
-
+  getCurrentRoutes() {
+    return this.refs.navigator.getCurrentRoutes()
+  }
   customAction(opts) {
     this.props.customAction(opts);
   }
@@ -285,6 +287,10 @@ class Router extends React.Component {
       this.setState({ titleProps: props });
     };
 
+    const getCurrentRoutes = () => {
+      return this.refs.navigator.getCurrentRoutes()
+    };
+
     const customAction = (opts) => {
       this.props.customAction(opts);
     };
@@ -315,6 +321,7 @@ class Router extends React.Component {
     this.setRightProps = setRightProps;
     this.setLeftProps = setLeftProps;
     this.setTitleProps = setTitleProps;
+    this.getCurrentRoutes = getCurrentRoutes;
     this.customAction = customAction;
 
     return (
@@ -335,6 +342,7 @@ class Router extends React.Component {
           setRightProps={setRightProps}
           setLeftProps={setLeftProps}
           setTitleProps={setTitleProps}
+          getCurrentRoutes={getCurrentRoutes}
           customAction={customAction}
           {...route.passProps}
         />

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class Router extends React.Component {
     this.setState({ titleProps: props });
   }
   getCurrentRoutes() {
-    return this.refs.navigator.getCurrentRoutes()
+    return this.refs.navigator.getCurrentRoutes();
   }
   customAction(opts) {
     this.props.customAction(opts);
@@ -288,7 +288,8 @@ class Router extends React.Component {
     };
 
     const getCurrentRoutes = () => {
-      return this.refs.navigator.getCurrentRoutes()
+      const routes = this.refs.navigator.getCurrentRoutes();
+      return routes;
     };
 
     const customAction = (opts) => {


### PR DESCRIPTION
Added **getCurrentRoutes** functionality without the need of ref. 
Since some projects cannot add ref to the router they cannot access **this.refs.navigator.getCurrentRoutes()**, hence, they cannot execute **getCurrentRoutes**. 
