### PR TITLE
Replace Deprecated BackAndroid with BackHandler

### DIFF
--- a/components/NavBarContainer.js
+++ b/components/NavBarContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  BackAndroid,
+  BackHandler,
   Platform,
   StyleSheet,
   Text,
@@ -68,7 +68,7 @@ class NavBarContainer extends React.Component {
 
   componentDidMount() {
     if (Platform.OS === 'android' && !!this.props.handleBackAndroid) {
-      BackAndroid.addEventListener('hardwareBackPress', () => {
+      BackHandler.addEventListener('hardwareBackPress', () => {
         if (this.props.currentRoute.index > 0) {
           this.goBack();
           return true;
@@ -89,7 +89,7 @@ class NavBarContainer extends React.Component {
 
   componentWillUnmount() {
     if (Platform.OS === 'android' && !!this.props.handleBackAndroid) {
-      BackAndroid.removeEventListener('hardwareBackPress');
+      BackHandler.removeEventListener('hardwareBackPress');
     }
   }
 


### PR DESCRIPTION
BackAndroid is deprecated and was completely removed from React Native 0.58.0+
This PR replaces all instances of BackAndroid with BackHandler